### PR TITLE
🐛🔧 Allowing root package require

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ request it. But can depend on it in the package.json file
 
 
 ## Usage
-```
+```javascript
 const gitmojiData = require('gitmoji-data/data/gitmojis.json');
 const GITMOJI_DATA_URL = 'https://raw.githubusercontent.com/gyran/gitmoji-data/master/data/gitmojis.json';
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gitmoji-data",
   "version": "1.1.0",
   "description": "A package other packages can depend on for getting the gitmoji data",
-  "main": "index.js",
+  "main": "data/gitmojis.json",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Now `require(‘gitmoji-data’)` will work

Also, makes syntax highlighting work in README